### PR TITLE
Fix device class default value

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,7 +17,7 @@ parameters:
       ssd:
         volume-group: vgssd
         spare-gb: 10
-        default: false
+        default: true
 
     storageclasses:
       ssd-local:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -21,14 +21,14 @@ default::
 topolvm:
   registry: quay.io
   repository: topolvm/topolvm-with-sidecar
-  tag: 0.8.3
+  tag: 0.9.0
 csi_provisioner:
   registry: k8s.gcr.io
   repository: sig-storage/csi-provisioner
   tag: v2.2.1
 ----
 
-The `csi_provisioner` uses a separate image, bc the current implementation in `topolvm-with-sidecar:0.8.3` contains a bug.
+The `csi_provisioner` uses a separate image, bc the current implementation in `topolvm-with-sidecar:0.9.0` contains a bug.
 
 This configuration shouldn't be touched and will be updated with future releases of this component.
 
@@ -43,7 +43,7 @@ default::
 ssd:
   volume-group: vgssd
   spare-gb: 10
-  default: false
+  default: true
 ----
 
 Each key represents a different device class.
@@ -67,7 +67,7 @@ This amount of space will be reserved on the volumegroup and not allocated or re
 [horizontal]
 type:: string
 
-If the storage class has no special parameter set, this device class will be used. Generally leave this as `false` and select the device class while configuring the storage class.
+If the storage class has no special parameter set, this device class will be used. However, one device class must be set as default.
 
 === Example
 
@@ -79,7 +79,7 @@ parameters:
       ssd:
         volume-group: vgssd
         spare-gb: 1
-        default: false
+        default: true
       hdd:
         volume-group: vghdd
         spare-gb: 5
@@ -158,7 +158,7 @@ parameters:
       ssd:
         volume-group: vgssd
         spare-gb: 10
-        default: false
+        default: true
 
     storageclasses:
       ssd-local:


### PR DESCRIPTION
If no device class is set as the default, topolvm won't start.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
