### PR TITLE
Use Kapitan Helm dependency type to fetch TopoLVM Helm chart

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,7 +4,7 @@ parameters:
     namespace: syn-topolvm
 
     charts:
-      topolvm: topolvm-chart-v3.1.1
+      topolvm: v3.1.1
 
     images:
       topolvm:

--- a/class/topolvm.yml
+++ b/class/topolvm.yml
@@ -1,10 +1,10 @@
 parameters:
   kapitan:
     dependencies:
-      - type: git
-        source: https://github.com/topolvm/topolvm
-        ref: ${topolvm:charts:topolvm}
-        subdir: charts/topolvm
+      - type: helm
+        source: https://topolvm.github.io/topolvm
+        chart_name: topolvm
+        version: ${topolvm:charts:topolvm}
         output_path: dependencies/topolvm/helmcharts/topolvm/${topolvm:charts:topolvm}/
     compile:
       # ArgoCD App


### PR DESCRIPTION
This ensures the component continues to work with Kapitan 0.30 (https://github.com/projectsyn/commodore/pull/358)

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
