### PR TITLE
Disable scheduler PDB when scheduler is disabled

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -70,6 +70,11 @@ parameters:
         enabled: false
         # scheduler.resources -- Specify resources on the TopoLVM scheduler extender container.
         resources: ${topolvm:resources:scheduler}
+        podDisruptionBudget:
+          # Only configure scheduler PDB if the scheduler is actually enabled.
+          # Otherwise we get unnecessary alert noise for the PDB because no
+          # scheduler pods are running.
+          enabled: ${topolvm:helmValues:scheduler:enabled}
 
       # lvmd service
       lvmd:


### PR DESCRIPTION
The helm chart doesn't check whether the scheduler itself is enabled when deciding whether to configure the scheduler PDB.

This commit uses the value of Helm value `scheduler.enabled` to set the default value of Helm value `scheduler.podDisruptionBudget.enabled`.

This should stop the spurious PodDisruptionBudgetAtLimit for the scheduler PDB when the scheduler isn't deployed at all.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
