### PR TITLE
Fix storageclass parameters when using non-legacy mode

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -31,9 +31,9 @@ local StorageClass(name='ssd-local') = sc.storageClass(name) {
   allowVolumeExpansion: params.storageclasses[name].volumeexpansion,
   parameters: {
     'csi.storage.k8s.io/fstype': params.storageclasses[name].fstype,
-    'topolvm.cybozu.com/device-class': params.storageclasses[name].class,
+    [if params.helm_values.useLegacy then 'topolvm.cybozu.com/device-class' else 'topolvm.io/device-class']: params.storageclasses[name].class,
   },
-  provisioner: 'topolvm.cybozu.com',
+  provisioner: if params.helm_values.useLegacy then 'topolvm.cybozu.com' else 'topolvm.io',
   volumeBindingMode: 'WaitForFirstConsumer',
   [if std.objectHas(params.storageclasses[name], 'retainpolicy') then 'reclaimPolicy']: params.storageclasses[name].retainpolicy,
 };

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -22,4 +22,17 @@ parameters:
 
   storageclass:
     defaults: {}
-    defaultClass: ""
+    defaultClass: ssd-local
+
+  topolvm:
+    deviceclasses:
+      - name: ssd
+        volume-group: vg-topolvm
+        default: true
+        spare-gb: 10
+    storageclasses:
+      ssd-local:
+        class: ssd
+        fstype: ext4
+        volumeexpansion: true
+        retainpolicy: Delete

--- a/tests/golden/defaults/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/configmap.yaml
+++ b/tests/golden/defaults/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  lvmd.yaml: |
-    socket-name: /run/topolvm/lvmd.sock
+  lvmd.yaml: "socket-name: /run/topolvm/lvmd.sock\ndevice-classes: \n  - default:\
+    \ true\n    name: ssd\n    spare-gb: 10\n    volume-group: vg-topolvm\n"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/golden/defaults/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/daemonset.yaml
+++ b/tests/golden/defaults/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9fd17cf1933ec71ec53f8e62217c13b82edafd9aee9db6429e4474b1a6fdbcd2
+        checksum/config: cacee65c76d69cc449b54f11a887ae2fbb9f6c2427e87dc2a337bc3df30ee883
       labels:
         app.kubernetes.io/component: lvmd
         app.kubernetes.io/instance: topolvm

--- a/tests/golden/defaults/topolvm/topolvm/22_storage_classes.yaml
+++ b/tests/golden/defaults/topolvm/topolvm/22_storage_classes.yaml
@@ -1,0 +1,17 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: 'true'
+  labels:
+    app.kubernetes.io/instance: topolvm
+    app.kubernetes.io/name: topolvm
+    name: ssd-local
+  name: ssd-local
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  topolvm.io/device-class: ssd
+provisioner: topolvm.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/tests/golden/legacy/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/configmap.yaml
+++ b/tests/golden/legacy/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  lvmd.yaml: |
-    socket-name: /run/topolvm/lvmd.sock
+  lvmd.yaml: "socket-name: /run/topolvm/lvmd.sock\ndevice-classes: \n  - default:\
+    \ true\n    name: ssd\n    spare-gb: 10\n    volume-group: vg-topolvm\n"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/golden/legacy/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/daemonset.yaml
+++ b/tests/golden/legacy/topolvm/topolvm/10_helmchart/topolvm/templates/lvmd/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9fd17cf1933ec71ec53f8e62217c13b82edafd9aee9db6429e4474b1a6fdbcd2
+        checksum/config: cacee65c76d69cc449b54f11a887ae2fbb9f6c2427e87dc2a337bc3df30ee883
       labels:
         app.kubernetes.io/component: lvmd
         app.kubernetes.io/instance: topolvm

--- a/tests/golden/legacy/topolvm/topolvm/22_storage_classes.yaml
+++ b/tests/golden/legacy/topolvm/topolvm/22_storage_classes.yaml
@@ -1,0 +1,16 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: topolvm
+    app.kubernetes.io/name: topolvm
+    name: ssd-local
+  name: ssd-local
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  topolvm.cybozu.com/device-class: ssd
+provisioner: topolvm.cybozu.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/tests/legacy.yml
+++ b/tests/legacy.yml
@@ -27,3 +27,14 @@ parameters:
   topolvm:
     helm_values:
       useLegacy: true
+    deviceclasses:
+      - name: ssd
+        volume-group: vg-topolvm
+        default: true
+        spare-gb: 10
+    storageclasses:
+      ssd-local:
+        class: ssd
+        fstype: ext4
+        volumeexpansion: true
+        retainpolicy: Delete


### PR DESCRIPTION
The storageclass parameters are wrong when using component in non-legacy mode.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
